### PR TITLE
Allow l2met-shuttle to operate like `tee`.

### DIFF
--- a/cmd/l2met-shuttle/main.go
+++ b/cmd/l2met-shuttle/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -11,22 +12,25 @@ import (
 )
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "usage: %v [--tee] <url>\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "usage: %v [options] <url>\n", os.Args[0])
+	flag.PrintDefaults()
 	os.Exit(1)
 }
 
 func parseArgs() (string, io.Writer) {
-	switch len(os.Args) {
-	case 2: // [l2met-shuttle, url]
-		return os.Args[1], ioutil.Discard
-	case 3: // [l2met-shuttle, --tee?, url]
-		if os.Args[1] == "--tee" {
-			return os.Args[2], os.Stdout
-		}
+	tee := flag.Bool("tee", false, "pipe input through to stdout")
+	flag.Parse()
+
+	if flag.NArg() != 1 {
+		usage()
 	}
 
-	usage()
-	return "", nil // unreachable
+	var out io.Writer = ioutil.Discard
+	if *tee {
+		out = os.Stdout
+	}
+
+	return flag.Arg(1), out
 }
 
 func main() {

--- a/io.go
+++ b/io.go
@@ -15,7 +15,7 @@ func Copy(ch chan<- []byte, r io.Reader, w io.Writer) error {
 		copy(cpy, line)
 		line = append(line, '\n')
 
-		if err := writeFully(w, line); err != nil {
+		if _, err := io.Copy(w, bytes.NewReader(line)); err != nil {
 			return err
 		}
 
@@ -23,19 +23,6 @@ func Copy(ch chan<- []byte, r io.Reader, w io.Writer) error {
 	}
 
 	return scanner.Err()
-}
-
-func writeFully(w io.Writer, bytes []byte) error {
-	for offset := 0; offset < len(bytes); {
-		written, err := w.Write(bytes[offset:])
-		if err != nil {
-			return err
-		}
-
-		offset += written
-	}
-
-	return nil
 }
 
 type reader struct {

--- a/io.go
+++ b/io.go
@@ -19,7 +19,7 @@ func Copy(ch chan<- []byte, r io.Reader, w io.Writer) error {
 			return err
 		}
 
-		ch <- []byte(line)
+		ch <- line
 	}
 
 	return scanner.Err()

--- a/io.go
+++ b/io.go
@@ -6,14 +6,37 @@ import (
 	"io"
 )
 
-func Copy(ch chan<- []byte, r io.Reader) error {
+func Copy(ch chan<- []byte, r io.Reader, w io.Writer) error {
 	scanner := bufio.NewScanner(r)
 
 	for scanner.Scan() {
-		ch <- []byte(scanner.Text() + "\n")
+		line := scanner.Text() + "\n"
+		if err := writeFully(w, line); err != nil {
+			return err
+		}
+
+		ch <- []byte(line)
 	}
 
 	return scanner.Err()
+}
+
+func writeFully(w io.Writer, str string) error {
+	bytes := []byte(str)
+	offset := 0
+
+	for offset < len(bytes) {
+		slice := bytes[offset:]
+
+		written, err := w.Write(slice)
+		if err != nil {
+			return err
+		}
+
+		offset += written
+	}
+
+	return nil
 }
 
 type reader struct {

--- a/io.go
+++ b/io.go
@@ -10,7 +10,11 @@ func Copy(ch chan<- []byte, r io.Reader, w io.Writer) error {
 	scanner := bufio.NewScanner(r)
 
 	for scanner.Scan() {
-		line := scanner.Text() + "\n"
+		line := scanner.Bytes()
+		cpy := make([]byte, len(line)+1)
+		copy(cpy, line)
+		line = append(line, '\n')
+
 		if err := writeFully(w, line); err != nil {
 			return err
 		}
@@ -21,14 +25,9 @@ func Copy(ch chan<- []byte, r io.Reader, w io.Writer) error {
 	return scanner.Err()
 }
 
-func writeFully(w io.Writer, str string) error {
-	bytes := []byte(str)
-	offset := 0
-
-	for offset < len(bytes) {
-		slice := bytes[offset:]
-
-		written, err := w.Write(slice)
+func writeFully(w io.Writer, bytes []byte) error {
+	for offset := 0; offset < len(bytes); {
+		written, err := w.Write(bytes[offset:])
 		if err != nil {
 			return err
 		}

--- a/io_test.go
+++ b/io_test.go
@@ -16,9 +16,8 @@ func TestCopy(t *testing.T) {
 	buf.WriteString("bar ")
 	buf.WriteString("baz\n")
 
-	out := new(bytes.Buffer)
-
-	go Copy(ch, buf, out)
+	var out bytes.Buffer
+	go Copy(ch, buf, &out)
 
 	assert.Equal(t, "foo\n", string(<-ch))
 	assert.Equal(t, "bar baz\n", string(<-ch))

--- a/io_test.go
+++ b/io_test.go
@@ -16,10 +16,14 @@ func TestCopy(t *testing.T) {
 	buf.WriteString("bar ")
 	buf.WriteString("baz\n")
 
-	go Copy(ch, buf)
+	out := new(bytes.Buffer)
+
+	go Copy(ch, buf, out)
 
 	assert.Equal(t, "foo\n", string(<-ch))
 	assert.Equal(t, "bar baz\n", string(<-ch))
+
+	assert.Equal(t, "foo\nbar baz\n", out.String())
 }
 
 func TestRead(t *testing.T) {


### PR DESCRIPTION
This will help improve some signal handling in start-l2met-shuttle (a wrapper
which attaches l2met-shuttle to stdout and stderr of a process). Right now,
that wrapper operates by using `tee` to forward streams to a fifo connected to
l2met-shuttle. If l2met-shuttle dies, the fifo simply goes unread, and tee
eventually blocks.

This change will allow the wrapper to connect stdout and stderr directly to
l2met-shuttle, so that if it exits the upstream process will receive SIGPIPE
and exit.

For compatibility with existing applications, this is optional, rather than the
new default behavior.