### PR TITLE
Fix off-by-one error in argument parsing.

### DIFF
--- a/cmd/l2met-shuttle/main.go
+++ b/cmd/l2met-shuttle/main.go
@@ -30,7 +30,7 @@ func parseArgs() (string, io.Writer) {
 		out = os.Stdout
 	}
 
-	return flag.Arg(1), out
+	return flag.Arg(0), out
 }
 
 func main() {


### PR DESCRIPTION
Running `l2met-shuttle URL` should not be equivalent to `l2met-shuttle ""`.