### PR TITLE
Process lines longer than bufio.MaxScanTokenSize

### DIFF
--- a/io.go
+++ b/io.go
@@ -7,13 +7,19 @@ import (
 )
 
 func Copy(ch chan<- []byte, r io.Reader) error {
-	scanner := bufio.NewScanner(r)
+	reader := bufio.NewReader(r)
 
-	for scanner.Scan() {
-		ch <- append(scanner.Bytes(), '\n')
+	for {
+		bytes, err := reader.ReadBytes('\n')
+		if len(bytes) > 0 {
+			ch <- bytes
+		}
+		if err == io.EOF {
+			return nil
+		} else if err != nil {
+			return err
+		}
 	}
-
-	return scanner.Err()
 }
 
 type reader struct {

--- a/io_test.go
+++ b/io_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -20,6 +21,25 @@ func TestCopy(t *testing.T) {
 
 	assert.Equal(t, "foo\n", string(<-ch))
 	assert.Equal(t, "bar baz\n", string(<-ch))
+}
+
+func TestCopyLongLine(t *testing.T) {
+	ch := make(chan []byte)
+
+	buf := new(bytes.Buffer)
+	buf.Grow(128 * 1024)
+	for i := 0; i < 128*1024; i++ {
+		buf.WriteByte('a')
+	}
+
+	go Copy(ch, buf)
+
+	select {
+	case <-time.After(time.Second * 1):
+		assert.Fail(t, "Timed out expecting line")
+	case line := <-ch:
+		assert.Equal(t, 128*1024, len(line))
+	}
 }
 
 func TestRead(t *testing.T) {


### PR DESCRIPTION
Inputs with lines longer than that (default: 64kb) were causing l2met-shuttle to crash in production. This change uses a different IO approach that can handle arbitrarily-long lines, so long as they fit in RAM.