### PR TITLE
ignore sigterm

### DIFF
--- a/cmd/l2met-shuttle/main.go
+++ b/cmd/l2met-shuttle/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	go func() {
 		sig := <-sigs
-        fmt.Printf("l2met-shuttle: received %v, ignoring\n", sig)
+		fmt.Printf("l2met-shuttle: received %v, ignoring\n", sig)
 	}()
 
 	url, in := parseArgs(os.Stdin)

--- a/cmd/l2met-shuttle/main.go
+++ b/cmd/l2met-shuttle/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	go func() {
 		sig := <-sigs
-		fmt.Printf("Received %v, ignoring", sig)
+        fmt.Printf("l2met-shuttle: received %v, ignoring", sig)
 	}()
 
 	url, in := parseArgs(os.Stdin)

--- a/cmd/l2met-shuttle/main.go
+++ b/cmd/l2met-shuttle/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	go func() {
 		sig := <-sigs
-        fmt.Printf("l2met-shuttle: received %v, ignoring", sig)
+        fmt.Printf("l2met-shuttle: received %v, ignoring\n", sig)
 	}()
 
 	url, in := parseArgs(os.Stdin)

--- a/cmd/l2met-shuttle/main.go
+++ b/cmd/l2met-shuttle/main.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/signal"
+	"syscall"
 
 	shuttle "github.com/heroku/l2met-shuttle"
 	lshuttle "github.com/heroku/log-shuttle"
@@ -33,6 +35,15 @@ func parseArgs(r io.Reader) (string, io.Reader) {
 }
 
 func main() {
+	sigs := make(chan os.Signal, 1)
+
+	signal.Notify(sigs, syscall.SIGTERM)
+
+	go func() {
+		sig := <-sigs
+		fmt.Printf("Received %v, ignoring", sig)
+	}()
+
 	url, in := parseArgs(os.Stdin)
 
 	ch := make(chan []byte)


### PR DESCRIPTION
This sets the `l2met-shuttle` program to *ignore* `SIGTERM` entirely.

This is because, on heroku dynos, the dyno manager sends `SIGTERM` to every process when doing a graceful shutdown. During that time period, we still want logging to happen and metrics to be sent.

The prior implementation of `l2met-shuttle` leads to all logs going missing the moment a dyno starts shutting down, and usually that will crash the "main" process `l2met-shuttle` is a sidecar for.